### PR TITLE
Fix protein Conv1d dimensions and align CNN architecture with paper

### DIFF
--- a/models/gat.py
+++ b/models/gat.py
@@ -51,8 +51,11 @@ class GATNet(torch.nn.Module):
         embedded_xt = torch.permute(embedded_xt, (0, 2, 1))
 
         conv_xt = self.conv_xt_1(embedded_xt)
+        conv_xt = self.relu(conv_xt)
         conv_xt = self.conv_xt_2(conv_xt)
+        conv_xt = self.relu(conv_xt)
         conv_xt = self.conv_xt_3(conv_xt)
+        conv_xt = self.relu(conv_xt)
         xt = torch.max(conv_xt, dim = -1)[0]
         xt = self.fc1_xt(xt)
 

--- a/models/gat_gcn.py
+++ b/models/gat_gcn.py
@@ -51,8 +51,11 @@ class GAT_GCN(torch.nn.Module):
         embedded_xt = torch.permute(embedded_xt, (0, 2, 1))
 
         conv_xt = self.conv_xt_1(embedded_xt)
+        conv_xt = self.relu(conv_xt)
         conv_xt = self.conv_xt_2(conv_xt)
+        conv_xt = self.relu(conv_xt)
         conv_xt = self.conv_xt_3(conv_xt)
+        conv_xt = self.relu(conv_xt)
         xt = torch.max(conv_xt, dim = -1)[0]
         xt = self.fc1_xt(xt)
 

--- a/models/gcn.py
+++ b/models/gcn.py
@@ -59,8 +59,11 @@ class GCNNet(torch.nn.Module):
         embedded_xt = torch.permute(embedded_xt, (0, 2, 1))
 
         conv_xt = self.conv_xt_1(embedded_xt)
+        conv_xt = self.relu(conv_xt)
         conv_xt = self.conv_xt_2(conv_xt)
+        conv_xt = self.relu(conv_xt)
         conv_xt = self.conv_xt_3(conv_xt)
+        conv_xt = self.relu(conv_xt)
         xt = torch.max(conv_xt, dim = -1)[0]
         xt = self.fc1_xt(xt)
 

--- a/models/gcn.py
+++ b/models/gcn.py
@@ -22,8 +22,10 @@ class GCNNet(torch.nn.Module):
 
         # protein sequence branch (1d conv)
         self.embedding_xt = nn.Embedding(num_features_xt + 1, embed_dim)
-        self.conv_xt_1 = nn.Conv1d(in_channels=1000, out_channels=n_filters, kernel_size=8)
-        self.fc1_xt = nn.Linear(32*121, output_dim)
+        self.conv_xt_1 = nn.Conv1d(in_channels=embed_dim, out_channels=n_filters, kernel_size=8)
+        self.conv_xt_2 = nn.Conv1d(in_channels=n_filters, out_channels=2*n_filters, kernel_size=8)
+        self.conv_xt_3 = nn.Conv1d(in_channels=2*n_filters, out_channels=3*n_filters, kernel_size=8)
+        self.fc1_xt = nn.Linear(3*n_filters, output_dim)
 
         # combined layers
         self.fc1 = nn.Linear(2*output_dim, 1024)
@@ -54,9 +56,12 @@ class GCNNet(torch.nn.Module):
 
         # 1d conv layers
         embedded_xt = self.embedding_xt(target)
+        embedded_xt = torch.permute(embedded_xt, (0, 2, 1))
+
         conv_xt = self.conv_xt_1(embedded_xt)
-        # flatten
-        xt = conv_xt.view(-1, 32 * 121)
+        conv_xt = self.conv_xt_2(conv_xt)
+        conv_xt = self.conv_xt_3(conv_xt)
+        xt = torch.max(conv_xt, dim = -1)[0]
         xt = self.fc1_xt(xt)
 
         # concat

--- a/models/ginconv.py
+++ b/models/ginconv.py
@@ -41,8 +41,10 @@ class GINConvNet(torch.nn.Module):
 
         # 1D convolution on protein sequence
         self.embedding_xt = nn.Embedding(num_features_xt + 1, embed_dim)
-        self.conv_xt_1 = nn.Conv1d(in_channels=1000, out_channels=n_filters, kernel_size=8)
-        self.fc1_xt = nn.Linear(32*121, output_dim)
+        self.conv_xt_1 = nn.Conv1d(in_channels=embed_dim, out_channels=n_filters, kernel_size=8)
+        self.conv_xt_2 = nn.Conv1d(in_channels=n_filters, out_channels=2*n_filters, kernel_size=8)
+        self.conv_xt_3 = nn.Conv1d(in_channels=2*n_filters, out_channels=3*n_filters, kernel_size=8)
+        self.fc1_xt = nn.Linear(3*n_filters, output_dim)
 
         # combined layers
         self.fc1 = nn.Linear(256, 1024)
@@ -68,9 +70,12 @@ class GINConvNet(torch.nn.Module):
         x = F.dropout(x, p=0.2, training=self.training)
 
         embedded_xt = self.embedding_xt(target)
+        embedded_xt = torch.permute(embedded_xt, (0, 2, 1))
+
         conv_xt = self.conv_xt_1(embedded_xt)
-        # flatten
-        xt = conv_xt.view(-1, 32 * 121)
+        conv_xt = self.conv_xt_2(conv_xt)
+        conv_xt = self.conv_xt_3(conv_xt)
+        xt = torch.max(conv_xt, dim = -1)[0]
         xt = self.fc1_xt(xt)
 
         # concat

--- a/models/ginconv.py
+++ b/models/ginconv.py
@@ -73,8 +73,11 @@ class GINConvNet(torch.nn.Module):
         embedded_xt = torch.permute(embedded_xt, (0, 2, 1))
 
         conv_xt = self.conv_xt_1(embedded_xt)
+        conv_xt = self.relu(conv_xt)
         conv_xt = self.conv_xt_2(conv_xt)
+        conv_xt = self.relu(conv_xt)
         conv_xt = self.conv_xt_3(conv_xt)
+        conv_xt = self.relu(conv_xt)
         xt = torch.max(conv_xt, dim = -1)[0]
         xt = self.fc1_xt(xt)
 


### PR DESCRIPTION
This pull request addresses the issues explained in #20, #12, and #13. 

Changes:
- Apply `Conv1d` along protein sequence dimension instead of the embedding dimension (the protein embedding matrix is permuted, and the number of `Conv1d` input/output channels is updated)
- Align the protein convolution network architecture with the [paper](https://doi.org/10.1093/bioinformatics/btaa921) (three consecutive Conv1d layers). 

Notes:
- The `Conv1d` dimension modification preserves sequential information in the protein embeddings.
- The three-layer protein CNN uses ascending channel sizes, with ReLU activations after each layer, following the [DeepDTA](https://github.com/hkmztrk/DeepDTA) implementation. 